### PR TITLE
configure and add roles to devise token auth

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -57,3 +57,4 @@ gem 'devise', '~> 4.9'
 gem 'devise_token_auth'
 
 gem 'ransack', '~> 3.0'
+gem "jsonapi-serializer", "~> 2.2"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.10.2)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -289,6 +291,7 @@ DEPENDENCIES
   devise (~> 4.9)
   devise_token_auth
   dotenv-rails
+  jsonapi-serializer (~> 2.2)
   pg (~> 1.1)
   puma (~> 6.0)
   pundit (~> 2.4)

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,49 @@
 class ApplicationController < ActionController::API
+  before_action :authenticate_user!, unless: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  include DeviseTokenAuth::Concerns::SetUserByToken
+  include Pundit::Authorization
+  include LocaleHandler
+  include ErrorHandler
+
+  rescue_from ActiveRecord::RecordNotFound, with: :handle_not_found
+  rescue_from Pundit::NotAuthorizedError, with: :handle_not_authorized
+  rescue_from ActionController::ParameterMissing, with: :handle_missing_parameter
+
+  private
+
+  def handle_not_found
+    render json: { error: I18n.t('errors.not_found') }, status: :not_found
+  end
+
+  def handle_not_authorized
+    render json: { error: I18n.t('errors.unauthorized') }, status: :forbidden
+  end
+
+  def handle_missing_parameter(exception)
+    param = exception.param || "parameter"
+    render json: { error: I18n.t('errors.parameter_missing', param: param) }, status: :bad_request
+  end
+
+  def ensure_id_present
+    unless params[:id].present?
+      render json: { error: I18n.t('errors.missing_id') }, status: :bad_request
+    end
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :password, :password_confirmation, :name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:email, :password, :password_confirmation, :name])
+  end
+
+  def render_success(resource, status: :ok)
+    render json: resource, status: status
+  end
+  
+  def render_failure(resource, status: :unprocessable_entity)
+    render json: resource.errors, status: status
+  end
 end

--- a/backend/app/controllers/materials_controller.rb
+++ b/backend/app/controllers/materials_controller.rb
@@ -1,41 +1,39 @@
 class MaterialsController < ApplicationController
-  before_action :set_material, only: %i[show update destroy]
-
   def index
-    @materials = Material.all
+    authorize Material
+    @materials = policy_scope(Material)
     render json: @materials
   end
 
   def show
-    render json: @material
+    authorize material
+    render json: material
   end
 
   def create
-    @material = Material.new(material_params)
-    if @material.save
-      render json: @material, status: :created
-    else
-      render json: { errors: @material.errors.full_messages }, status: :unprocessable_entity
-    end
+    authorize Material
+    @material = Material.create!(material_params)
+    render json: @material, status: :created
   end
 
   def update
-    if @material.update(material_params)
-      render json: @material
-    else
-      render json: { errors: @material.errors.full_messages }, status: :unprocessable_entity
-    end
+    authorize material
+    material.update!(material_params)
+    render json: material, status: :ok
   end
 
   def destroy
-    @material.destroy
+    authorize material
+    material.destroy
     head :no_content
   end
 
   private
 
-  def set_material
-    @material = Material.find(params[:id])
+  def material
+    @material ||= Material.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: I18n.t('errors.not_found') }, status: :not_found
   end
 
   def material_params

--- a/backend/app/controllers/prestadors_controller.rb
+++ b/backend/app/controllers/prestadors_controller.rb
@@ -1,43 +1,39 @@
 class PrestadorsController < ApplicationController
-  before_action :set_prestador, only: [:show, :update, :destroy]
-
   def index
-    @prestadors = Prestador.all
+    authorize Prestador
+    @prestadors = policy_scope(Prestador)
     render json: @prestadors
   end
 
   def show
-    render json: @prestador
+    authorize prestador
+    render json: prestador
   end
 
   def create
-    @prestador = Prestador.new(prestador_params)
-    if @prestador.save
-      render json: @prestador, status: :created
-    else
-      render json: { errors: @prestador.errors.full_messages }, status: :unprocessable_entity
-    end
+    authorize Prestador
+    @prestador = Prestador.create!(prestador_params)
+    render json: @prestador, status: :created
   end
 
   def update
-    if @prestador.update(prestador_params)
-      render json: @prestador
-    else
-      render json: { errors: @prestador.errors.full_messages }, status: :unprocessable_entity
-    end
+    authorize prestador
+    prestador.update!(prestador_params)
+    render json: prestador, status: :ok
   end
 
   def destroy
-    @prestador.destroy
+    authorize prestador
+    prestador.destroy
     head :no_content
   end
 
   private
 
-  def set_prestador
-    @prestador = Prestador.find(params[:id])
+  def prestador
+    @prestador ||= Prestador.find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    render json: { error: "Prestador não encontrado" }, status: :not_found
+    render json: { error: I18n.t('errors.not_found') }, status: :not_found
   end
 
   def prestador_params

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -1,62 +1,40 @@
-# frozen_string_literal: true
-
 class UsersController < ApplicationController
-  include ErrorHandler
-  include LocaleHandler
-
-  before_action :set_user, only: %i[show update destroy]
-
   def index
-    @users = User.all
-    render json: @users
+    authorize User
+    @q = policy_scope(User).ransack(params[:q])
+    @users = @q.result
+
+    render json: @users.map { |user| UserSerializer.call(user) }
   end
 
   def show
-    render json: @user
+    authorize user
+    render json: UserSerializer.call(user)
   end
 
   def create
-    @user = User.new(user_params)
-    if @user.save
-      render json: @user, status: :created
-    else
-      render_error(@user)
-    end
+    authorize User
+    @user = User.create!(permitted_attributes(User))
+    render json: UserSerializer.call(@user), status: :created
   end
 
   def update
-    if @user.update(user_params)
-      render json: @user
-    else
-      render_error(@user)
-    end
+    authorize user
+    user.update!(permitted_attributes(User))
+    render json: UserSerializer.call(user), status: :ok
   end
 
   def destroy
-    @user.destroy
+    authorize user
+    raise Pundit::NotAuthorizedError if user.id == current_user.id
+    user.destroy
+
     head :no_content
   end
 
   private
 
-  def set_user
-    @user = User.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render_not_found('User')
-  end
-
-  def user_params
-    params.require(:user).permit(
-      :name,
-      :email,
-      :password,
-      :password_confirmation,
-      :role,
-      :provider,
-      :uid,
-      :cpf,
-      :tipo_contrato,
-      :ativo
-    )
+  def user
+    @user ||= User.find(params[:id])
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,14 +1,23 @@
 class User < ApplicationRecord
-    has_secure_password
+  include DeviseTokenAuth::Concerns::User
   
-    enum role: { admin: 0, gerente: 1, contratado: 2 }
+  devise :database_authenticatable, :registerable, :recoverable,
+  :rememberable, :validatable, :lockable
   
-    has_one :colaborador, foreign_key: :id, primary_key: :id, dependent: :destroy
-    has_many :entregas_epi, foreign_key: :id_colaborador, class_name: "EntregaEpi", dependent: :nullify
-    has_many :contratos_colaborador, foreign_key: :id_colaborador, class_name: "ContratoColaborador", dependent: :nullify
+  enum role: { admin: 0, gerente: 1, contratado: 2 }
   
-    validates :name, presence: true
-    validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-    validates :cpf, format: { with: /\A\d{11}\z/, message: "deve conter 11 dígitos" }, allow_blank: true
-    validates :role, presence: true
+  has_one :colaborador, foreign_key: :id, primary_key: :id, dependent: :destroy
+  has_many :entregas_epi, foreign_key: :id_colaborador, class_name: "EntregaEpi", dependent: :nullify
+  has_many :contratos_colaborador, foreign_key: :id_colaborador, class_name: "ContratoColaborador", dependent: :nullify
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :cpf, format: { with: /\A\d{11}\z/, message: "deve conter 11 dígitos" }, allow_blank: true
+  validates :role, presence: true
+
+  private
+
+  def skip_confirmation!
+    self.confirmed_at = Time.current
   end
+end

--- a/backend/app/policies/application_policy.rb
+++ b/backend/app/policies/application_policy.rb
@@ -1,0 +1,51 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/backend/app/policies/material_policy.rb
+++ b/backend/app/policies/material_policy.rb
@@ -1,0 +1,28 @@
+class MaterialPolicy < ApplicationPolicy
+    def index?
+      true
+    end
+  
+    def show?
+      true
+    end
+  
+    def create?
+      user.admin?
+    end
+  
+    def update?
+      user.admin?
+    end
+  
+    def destroy?
+      user.admin?
+    end
+  
+    class Scope < Scope
+      def resolve
+        scope.all
+      end
+    end
+  end
+  

--- a/backend/app/policies/prestador_policy.rb
+++ b/backend/app/policies/prestador_policy.rb
@@ -1,0 +1,28 @@
+class PrestadorPolicy < ApplicationPolicy
+    def index?
+      true
+    end
+  
+    def show?
+      true
+    end
+  
+    def create?
+      user.admin?
+    end
+  
+    def update?
+      user.admin?
+    end
+  
+    def destroy?
+      user.admin?
+    end
+  
+    class Scope < Scope
+      def resolve
+        scope.all
+      end
+    end
+  end
+  

--- a/backend/app/policies/user_policy.rb
+++ b/backend/app/policies/user_policy.rb
@@ -1,0 +1,31 @@
+class UserPolicy < ApplicationPolicy
+  def index?
+    user.admin?
+  end
+
+  def show?
+    user.admin? || user.id == record.id
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin? || (user.role == 'user' && user.id == record.id)
+  end
+
+  def destroy?
+    user.admin? && user.id != record.id
+  end
+
+  def permitted_attributes
+    [:name, :email, :password, :cpf, :role, :tipo_contrato, :ativo, :admin]
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      user.admin? ? scope.all : scope.none
+    end
+  end
+end

--- a/backend/app/serializers/application_serializer.rb
+++ b/backend/app/serializers/application_serializer.rb
@@ -1,0 +1,8 @@
+class ApplicationSerializer
+    def self.serialize_timestamps(record)
+      {
+        created_at: record.respond_to?(:created_at) && record.created_at.present? ? record.created_at.strftime('%d/%m/%Y %H:%M') : nil,
+        updated_at: record.respond_to?(:updated_at) && record.updated_at.present? ? record.updated_at.strftime('%d/%m/%Y %H:%M') : nil
+      }
+    end
+  end

--- a/backend/app/serializers/material_serializer.rb
+++ b/backend/app/serializers/material_serializer.rb
@@ -1,0 +1,5 @@
+class MaterialSerializer
+    include JSONAPI::Serializer
+    attributes :id, :nome, :categoria, :unidade_medida, :quantidade_minima, :quantidade_atual, :created_at, :updated_at
+  end
+  

--- a/backend/app/serializers/prestador_serializer.rb
+++ b/backend/app/serializers/prestador_serializer.rb
@@ -1,0 +1,4 @@
+class PrestadorSerializer
+    include JSONAPI::Serializer
+    attributes :id, :nome, :cnpj, :endereco, :telefone, :email, :created_at, :updated_at
+  end

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,0 +1,15 @@
+class UserSerializer < ApplicationSerializer
+  def self.call(user)
+    base_data = {
+      name: user.name,
+      email: user.email,
+      cpf:  user.cpf,
+      role: user.role,
+      tipo_contrato: user.tipo_contrato,
+      ativo: user.ativo,
+      admin: user.admin?
+    }
+
+    base_data.merge(serialize_timestamps(user))
+  end
+end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -1,17 +1,7 @@
 require_relative "boot"
 
-require "rails"
+require "rails/all"
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_mailbox/engine"
-require "action_text/engine"
-require "action_view/railtie"
-require "action_cable/engine"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
@@ -40,5 +30,12 @@ module Backend
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, key: '_backend_session'
+    config.middleware.use Rack::MethodOverride
+    
+    # Internationalization (I18n) Configuration
+    config.i18n.default_locale = :en
+    config.i18n.available_locales = [:en, :'pt-BR']
   end
 end

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '6293dedc2a826e866a2f4295cfe15e9cab1eff4c3d7335baa8624c1ac3e1d40585e8c333ba62d64f6fdeecb02e2e92df47b5c16dc2adb5c809ed6b0890e25031'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'a657b06f4ccb041b0f413477f44708c58a0f1acb6bb2aa2d25074330c9aa7c76655c6125926b78c2e595b6892a7bf9946d4bb402d59b201681bd408a71905195'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  config.maximum_attempts = 5
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  config.change_headers_on_each_request = false
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {
+  #   :'authorization' => 'Authorization',
+  #   :'access-token' => 'access-token',
+  #   :'client' => 'client',
+  #   :'expiry' => 'expiry',
+  #   :'uid' => 'uid',
+  #   :'token-type' => 'token-type'
+  # }
+
+  # Makes it possible to use custom uid column
+  # config.other_uid = "foo"
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  config.enable_standard_devise_support = true
+
+  # By default DeviseTokenAuth will not send confirmation email, even when including
+  # devise confirmable module. If you want to use devise confirmable module and
+  # send email, set it to true. (This is a setting for compatibility)
+  # config.send_confirmation_email = true
+end

--- a/backend/config/locales/devise.en.yml
+++ b/backend/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -28,4 +28,7 @@
 #       enabled: "ON"
 
 en:
-  hello: "Hello world"
+  errors:
+    not_found: "Resource not found."
+    unauthorized: "You are not authorized to perform this action."
+    parameter_missing: "Missing required parameter: %{param}."

--- a/backend/config/locales/errors.en.yml
+++ b/backend/config/locales/errors.en.yml
@@ -1,0 +1,7 @@
+en:
+  errors:
+    unauthorized: "You are not authorized to perform this action."
+    not_found: "Resource not found."
+    missing_params: "Nenhum parâmetro foi enviado."
+    internal_server_error: "An unexpected error occurred. Please try again later."
+    parameter_missing: "Missing required parameter: %{param}."

--- a/backend/config/locales/errors.pt-BR.yml
+++ b/backend/config/locales/errors.pt-BR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  errors:
+    unauthorized: "Você não tem autorização para realizar esta ação."
+    not_found: "Recurso não encontrado."
+    internal_server_error: "Ocorreu um erro inesperado. Tente novamente mais tarde."

--- a/backend/config/locales/pt-BR.yml
+++ b/backend/config/locales/pt-BR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  errors:
+    not_found: "Recurso não encontrado."
+    unauthorized: "Você não tem autorização para realizar esta ação."
+    parameter_missing: "Parâmetro obrigatório ausente: %{param}."

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth'
+
   resources :epis, only: %i[index show create update destroy]
   resources :entrega_epi, only: %i[index show create update destroy]
   resources :materials, only: %i[index show create update destroy]

--- a/backend/db/migrate/20250506130255_add_devise_token_auth_to_users.rb
+++ b/backend/db/migrate/20250506130255_add_devise_token_auth_to_users.rb
@@ -1,0 +1,20 @@
+class AddDeviseTokenAuthToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :provider, :string, null: false, default: "email"
+    add_column :users, :uid, :string, null: false, default: ""
+    add_column :users, :encrypted_password, :string, null: false, default: "" 
+    add_column :users, :tokens, :json
+    add_column :users, :allow_password_change, :boolean, default: false
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+    add_column :users, :remember_created_at, :datetime
+    add_column :users, :reset_password_token, :string
+    add_column :users, :reset_password_sent_at, :datetime
+
+    add_index :users, [:uid, :provider], unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token, unique: true
+  end
+end

--- a/backend/db/migrate/20250506200641_remove_password_digest_from_users.rb
+++ b/backend/db/migrate/20250506200641_remove_password_digest_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordDigestFromUsers < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :users, :password_digest, :string
+  end
+end

--- a/backend/db/migrate/20250507111531_add_lockable_to_users.rb
+++ b/backend/db/migrate/20250507111531_add_lockable_to_users.rb
@@ -1,0 +1,9 @@
+class AddLockableToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :failed_attempts, :integer, default: 0, null: false 
+    add_column :users, :unlock_token, :string 
+    add_column :users, :locked_at, :datetime 
+
+    add_index :users, :unlock_token, unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_23_141744) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_07_111531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -131,13 +131,31 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_23_141744) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
-    t.string "password_digest"
     t.integer "role"
     t.string "cpf"
     t.string "tipo_contrato"
     t.boolean "ativo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.json "tokens"
+    t.boolean "allow_password_change", default: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.datetime "remember_created_at"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
   add_foreign_key "entrega_epis", "epis"

--- a/backend/db/seeds/users.rb
+++ b/backend/db/seeds/users.rb
@@ -22,7 +22,8 @@ users.each do |attrs|
     role: attrs[:role],
     cpf: attrs[:cpf],
     tipo_contrato: attrs[:tipo_contrato],
-    ativo: attrs[:ativo]
+    ativo: attrs[:ativo],
+    confirmed_at: Time.current 
   )
 end
 


### PR DESCRIPTION
# 🚀 Add Devise Token Auth and User Roles Integration

## 📌 Descrição

Este PR implementa autenticação baseada em tokens utilizando a gem **Devise Token Auth**, integrando-a ao modelo `User`. Além disso, adiciona o suporte a **roles** para diferenciar os tipos de usuários na aplicação.

## ✅ Alterações principais

- Instalação e configuração da gem `devise_token_auth`
- Configuração inicial do Devise
- Adição de novos campos ao modelo `User` para suportar autenticação via token
- Criação de policies com Pundit:
  - `ApplicationPolicy`
  - `UserPolicy`
  - `MaterialPolicy`
  - `PrestadorPolicy`
- Serializers:
  - `UserSerializer`
  - `MaterialSerializer`
  - `PrestadorSerializer`
- Rotas atualizadas com `mount_devise_token_auth_for 'User', at: 'auth'`
- Migrações criadas para ajustes no banco:
  - Inclusão dos campos do Devise
  - Remoção de `password_digest`
  - Inclusão do módulo `lockable`

## 📂 Arquivos adicionados

- `app/policies/*`
- `app/serializers/*`
- `config/initializers/devise*.rb`
- `config/locales/devise.en.yml`, `pt-BR.yml`, `errors.*.yml`
- Migrações `add_devise_token_auth_to_users`, `remove_password_digest_from_users`, `add_lockable_to_users`

## 🧪 Como testar

1. Atualize as dependências do projeto:
   ```bash
   bundle install

2. Rode as migrações:
   ```bash
   rails db:migration

3. (Opcional) Exclua os dados existentes no banco, se necessário:
   ```bash
   rails db:drop db:create db:migrate

4. Execute as seeds para popular o banco com dados iniciais:
   ```bash
rails db:seed
