### PR TITLE
create model, crud, serializer, policy, route and seed for cargos

### DIFF
--- a/backend/app/controllers/cargos_controller.rb
+++ b/backend/app/controllers/cargos_controller.rb
@@ -1,0 +1,49 @@
+class CargosController < ApplicationController
+  before_action :set_cargo, only: [:show, :update, :destroy]
+  before_action :authorize_cargo, only: [:show, :update, :destroy]
+  before_action :authorize_collection, only: [:index, :create]
+
+  def index
+    cargos = policy_scope(Cargo).ransack(params[:q]).result
+    render json: cargos.map(&CargoSerializer.method(:call))
+  end
+
+  def show
+    render json: CargoSerializer.call(@cargo)
+  end
+
+  def create
+    cargo = Cargo.new(cargo_params)
+    authorize cargo
+    cargo.save!
+    render json: CargoSerializer.call(cargo), status: :created
+  end
+
+  def update
+    @cargo.update!(cargo_params)
+    render json: CargoSerializer.call(@cargo)
+  end
+
+  def destroy
+    @cargo.destroy!
+    head :no_content
+  end
+
+  private
+
+  def set_cargo
+    @cargo = Cargo.find(params[:id])
+  end
+
+  def cargo_params
+    params.require(:cargo).permit(:nome)
+  end
+
+  def authorize_cargo
+    authorize @cargo
+  end
+
+  def authorize_collection
+    authorize Cargo
+  end
+end

--- a/backend/app/models/cargo.rb
+++ b/backend/app/models/cargo.rb
@@ -1,0 +1,8 @@
+class Cargo < ApplicationRecord
+
+  validates :nome, presence: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[nome]
+  end
+end

--- a/backend/app/policies/cargo_policy.rb
+++ b/backend/app/policies/cargo_policy.rb
@@ -1,0 +1,27 @@
+class CargoPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+
+  def destroy?
+    user.admin?
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/backend/app/serializers/cargo_serializer.rb
+++ b/backend/app/serializers/cargo_serializer.rb
@@ -1,0 +1,8 @@
+class CargoSerializer
+  def self.call(cargo)
+    {
+      id: cargo.id,
+      nome: cargo.nome
+    }
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  get 'cargos/index'
+  get 'cargos/show'
+  get 'cargos/create'
+  get 'cargos/update'
+  get 'cargos/destroy'
   mount_devise_token_auth_for 'User', at: 'auth'
   
   resources :colaboradors
@@ -12,4 +17,5 @@ Rails.application.routes.draw do
   resources :dependentes, only: %i[index show create update destroy]
   resources :contatos, only: %i[index show create update destroy]
   resources :empresas, only: %i[index show create update destroy]
+  resources :cargos, only: %i[index show create update destroy]
 end

--- a/backend/db/migrate/20250524164548_create_cargos.rb
+++ b/backend/db/migrate/20250524164548_create_cargos.rb
@@ -1,0 +1,9 @@
+class CreateCargos < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cargos do |t|
+      t.string :nome
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_23_163047) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_24_164548) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_23_163047) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "cargos", force: :cascade do |t|
+    t.string "nome"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "clientes", force: :cascade do |t|

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -10,5 +10,6 @@ load Rails.root.join("db/seeds/empresas.rb")
 load(Rails.root.join('db/seeds/dependentes.rb'))
 load Rails.root.join('db/seeds/enderecos.rb')
 load Rails.root.join("db/seeds/contatos.rb")
+load Rails.root.join("db/seeds/cargos.rb")
 
 puts "Seed finalizada!"

--- a/backend/db/seeds/cargos.rb
+++ b/backend/db/seeds/cargos.rb
@@ -1,0 +1,9 @@
+puts '🌱 Criando cargos...'
+
+Cargo.create!([
+  { nome: 'Desenvolvedor' },
+  { nome: 'Designer' },
+  { nome: 'Gerente' }
+])
+
+puts '✅ Cargos criados com sucesso!'

--- a/backend/spec/models/cargo_spec.rb
+++ b/backend/spec/models/cargo_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Cargo, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/policies/cargo_policy_spec.rb
+++ b/backend/spec/policies/cargo_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe CargoPolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+
+  permissions ".scope" do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :show? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :create? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :update? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :destroy? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end

--- a/backend/spec/requests/cargos_spec.rb
+++ b/backend/spec/requests/cargos_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe "Cargos", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/cargos/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/cargos/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/cargos/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /update" do
+    it "returns http success" do
+      get "/cargos/update"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/cargos/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## ✨ Feature: CRUD de Cargo com Busca

Este PR adiciona o CRUD completo para a model `Cargo`, com:

- [x] Controller 
- [x] Busca no `index` com **Ransack** (`q[nome_cont]=X`)
- [x] Uso de **Serializer callable**: `CargoSerializer.call(cargo)`
- [x] Policy controlada via `ApplicationController`
- [x] Testado com requisições via Postman

