### PR TITLE
Adicionando a tabela documentos e sua rota

### DIFF
--- a/backend/app/controllers/documents_controller.rb
+++ b/backend/app/controllers/documents_controller.rb
@@ -1,0 +1,51 @@
+class DocumentsController < ApplicationController
+  before_action :set_document, only: [:show, :update, :destroy]
+
+  def index
+    @documents = Document.all
+    render json: @documents
+  end
+
+  def show
+    render json: @document
+  end
+
+  def create
+    @document = Document.new(document_params)
+
+    if @document.save
+      render json: @document, status: :created
+    else
+      render json: @document.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @document.update(document_params)
+      render json: @document
+    else
+      render json: @document.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @document.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_document
+    @document = Document.find(params[:id])
+  end
+
+  def document_params
+    params.require(:document).permit(
+      :tipo,
+      :numero,
+      :orgao_emissor,
+      :data_emissao,
+      :employee_id
+    )
+  end
+end

--- a/backend/app/models/document.rb
+++ b/backend/app/models/document.rb
@@ -1,0 +1,8 @@
+class Document < ApplicationRecord
+  belongs_to :employee
+
+  validates :tipo, presence: true
+  validates :numero, presence: true, uniqueness: { scope: :employee_id }
+  validates :orgao_emissor, presence: true
+  validates :data_emissao, presence: true
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   resources :companies, only: %i[index show create update destroy]
   resources :positions, only: %i[index show create update destroy]
   resources :certifications, only: %i[index show create update destroy]
+  resources :documents, only: %i[index show create update destroy]
   resources :departments, only: %i[index show create update destroy]
   resources :employee_contracts, only: %i[index show create update destroy]
   resources :asos

--- a/backend/db/migrate/20250610191936_create_documents.rb
+++ b/backend/db/migrate/20250610191936_create_documents.rb
@@ -1,0 +1,13 @@
+class CreateDocuments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :documents do |t|
+      t.string :tipo
+      t.string :numero
+      t.string :orgao_emissor
+      t.date :data_emissao
+      t.references :employee, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_09_104634) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_10_191936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -156,6 +156,17 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_09_104634) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["employee_id"], name: "index_dependents_on_employee_id"
+  end
+
+  create_table "documents", force: :cascade do |t|
+    t.string "tipo"
+    t.string "numero"
+    t.string "orgao_emissor"
+    t.date "data_emissao"
+    t.bigint "employee_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["employee_id"], name: "index_documents_on_employee_id"
   end
 
   create_table "emergency_contacts", force: :cascade do |t|
@@ -366,6 +377,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_09_104634) do
   add_foreign_key "certifications", "employees"
   add_foreign_key "certifications", "positions"
   add_foreign_key "dependents", "employees"
+  add_foreign_key "documents", "employees"
   add_foreign_key "emergency_contacts", "employees"
   add_foreign_key "employee_contracts", "departments"
   add_foreign_key "employee_contracts", "employees"

--- a/backend/spec/factories/documents.rb
+++ b/backend/spec/factories/documents.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :document do
+    tipo { "MyString" }
+    numero { "MyString" }
+    orgao_emissor { "MyString" }
+    data_emissao { "2025-06-10" }
+    colaborador { nil }
+  end
+end

--- a/backend/spec/models/document_spec.rb
+++ b/backend/spec/models/document_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Document, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/requests/documents_spec.rb
+++ b/backend/spec/requests/documents_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe "Documents", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/documents/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/documents/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/documents/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /update" do
+    it "returns http success" do
+      get "/documents/update"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/documents/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
### O que foi feito

- Criação da tabela `documents`
- Adição do model `Document` com os campos:
  - `tipo` (string)
  - `numero` (string)
  - `orgao_emissor` (string)
  - `data_emissao` (date)
  - `employee_id` (referência a `employees`)
- Criação do controller `DocumentsController` com as ações REST (index, show, create, update, destroy)
- Adição das rotas para `/documents`
- Associação com o model `Employee`

### Motivação

Essa tabela faz parte da estrutura de documentos pessoais vinculados aos colaboradores (employees), permitindo o controle de informações como CNH, RG, etc., com vínculo direto ao funcionário.

### Como testar

- Rodar `rails db:migrate` para aplicar a migração
- Fazer requisições `GET`, `POST`, `PATCH` e `DELETE` para o endpoint `/documents` (via Postman ou curl)
- Verificar se os documentos são corretamente associados a um `employee`

### Checklist

- [x] Migration criada e aplicada
- [x] Model implementado com associações e validações básicas
- [x] Controller funcional
- [x] Rotas REST adicionadas
- [x] Testado com Postman

---